### PR TITLE
Add periodic heartbeat message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # wg-cop
 Telegram Bot to track rommate social credit score and, if prompted, exercise microauthority.
 
+The bot sends an "I'm alive" message every four hours to confirm it is running.
+
 haha was suechsch

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # wg-cop
 Telegram Bot to track rommate social credit score and, if prompted, exercise microauthority.
 
-The bot sends an "I'm alive" message every four hours to confirm it is running.
+The bot sends an "I'm alive" message every four hours to confirm it is running to the "bothandler user id" specified in config.py.
 
 haha was suechsch

--- a/maBot.py
+++ b/maBot.py
@@ -554,6 +554,14 @@ def setup_weekly_job(application):
     )
 
 
+async def send_alive(context: CallbackContext) -> None:
+    """Send a periodic heartbeat message to confirm the bot is running."""
+    try:
+        await context.bot.send_message(chat_id=GROUP_CHAT_ID, text="I'm alive")
+    except TelegramError as e:
+        logger.error(f"Failed to send heartbeat: {e}")
+
+
 async def cancel(update: Update, context: CallbackContext) -> int:
     await update.message.reply_text(
         "Cancelled. Back to main menu.", reply_markup=get_main_keyboard()
@@ -656,6 +664,12 @@ def main():
     app.add_handler(chore_conv)
 
     setup_weekly_job(app)
+    app.job_queue.run_repeating(
+        send_alive,
+        interval=timedelta(hours=4).total_seconds(),
+        first=0,
+        name="heartbeat",
+    )
     logger.info("Bot running...")
     app.run_polling()
 

--- a/maBot.py
+++ b/maBot.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 # Bot Token
 from config import TOKEN
 from config import GROUP_CHAT_ID
+from config import BOT_HANDLER_ID
 
 # Data storage
 DATA_FILE = "wg_data_beta.json"
@@ -516,12 +517,12 @@ async def check_weekly_penalties(context: CallbackContext) -> None:
 
     current_date = datetime.now().strftime("%Y-%m-%d")
     if violators:
-        report = f"📊 Weekly Chore Report ({current_date}):\n\n"
-        report += f"👑 Leader: {leader} with {leader_points} points\n\n"
+        report = f"Weekly Chore Report ({current_date}):\n\n"
+        report += f"Leader: {leader} with {leader_points} points\n\n"
         report += "Penalties:\n" + "\n".join(violators)
     else:
-        report = f"📊 Weekly Chore Report ({current_date}):\n\n"
-        report += f"👑 Leader: {leader} with {leader_points} points\n\n"
+        report = f"Weekly Chore Report ({current_date}):\n\n"
+        report += f"Leader: {leader} with {leader_points} points\n\n"
         report += "Everyone is keeping up with their chores! No penalties this week. 🎉"
 
     try:
@@ -557,7 +558,7 @@ def setup_weekly_job(application):
 async def send_alive(context: CallbackContext) -> None:
     """Send a periodic heartbeat message to confirm the bot is running."""
     try:
-        await context.bot.send_message(chat_id=GROUP_CHAT_ID, text="I'm alive")
+        await context.bot.send_message(chat_id=BOT_HANDLER_ID, text="I'm alive")
     except TelegramError as e:
         logger.error(f"Failed to send heartbeat: {e}")
 


### PR DESCRIPTION
## Summary
- add `send_alive` job that posts "I'm alive" every four hours
- document heartbeat behavior in README

## Testing
- `python -m py_compile maBot.py`


------
https://chatgpt.com/codex/tasks/task_e_68acc23dc08c832d8a3b116ef6f3f3e0